### PR TITLE
Necessary fixes to run tests and avoid problems with quota

### DIFF
--- a/web-server/bastion.tf3
+++ b/web-server/bastion.tf3
@@ -18,6 +18,9 @@ resource "oci_core_instance" "Bastion" {
   }
 
   shape     = var.TestServerShape
+  shape_config {
+    ocpus = 1
+  }
 
   metadata = {
     ssh_authorized_keys = file(var.ssh_public_key)

--- a/web-server/compute.tf5
+++ b/web-server/compute.tf5
@@ -13,6 +13,9 @@ resource "oci_core_instance" "WebServer" {
   }
 
   shape     = var.TestServerShape
+  shape_config {
+    ocpus = 1
+  }
   create_vnic_details {
     hostname_label = "web${count.index}"
     subnet_id = oci_core_subnet.PrivateSubnet.id

--- a/web-server/lb.tf7
+++ b/web-server/lb.tf7
@@ -3,7 +3,7 @@
 ## Variables
 ##########################################################################################
 variable "load_balancer_shape" {
-  default = "100Mbps"
+  default = "400Mbps"
 }
 
 variable "LBCount" {

--- a/web-server/outputs.tf
+++ b/web-server/outputs.tf
@@ -1,8 +1,8 @@
 # Output the private and public IPs of the instance
 
-# output "WebServerPrivateIPs" {
-#   value = [oci_core_instance.WebServer.*.private_ip]
-# }
+output "WebServerPrivateIPs" {
+  value = [oci_core_instance.WebServer.*.private_ip]
+}
 
 # output "WebServerPublicIPs" {
 #   value = ["${oci_core_instance.WebServer.*.public_ip}"]
@@ -16,9 +16,9 @@
 #   value = [oci_core_subnet.PrivateSubnet.*.subnet_domain_name]
 # }
 
-# output "BastionPublicIP" {
-#   value = [oci_core_instance.Bastion.*.public_ip]
-# }
+output "BastionPublicIP" {
+  value = [oci_core_instance.Bastion.*.public_ip]
+}
 
 output "VcnID" {
   value = [oci_core_virtual_network.VCN.id]

--- a/web-server/terratest/terraform_oci_test.go
+++ b/web-server/terratest/terraform_oci_test.go
@@ -56,7 +56,7 @@ func terraformEnvOptions(t *testing.T) {
 
 	ipMatcher := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`)
 
-	bastionIPs := terraform.Output(t, options, "lb_ip")
+	bastionIPs := terraform.Output(t, options, "BastionPublicIP")
 	bastionCount = len(ipMatcher.FindAllStringIndex(bastionIPs, -1))
 
 	webServerIPs := terraform.Output(t, options, "WebServerPrivateIPs")

--- a/web-server/terratest/terraform_oci_test.go
+++ b/web-server/terratest/terraform_oci_test.go
@@ -56,7 +56,7 @@ func terraformEnvOptions(t *testing.T) {
 
 	ipMatcher := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+`)
 
-	bastionIPs := terraform.Output(t, options, "BastionPublicIP")
+	bastionIPs := terraform.Output(t, options, "lb_ip")
 	bastionCount = len(ipMatcher.FindAllStringIndex(bastionIPs, -1))
 
 	webServerIPs := terraform.Output(t, options, "WebServerPrivateIPs")

--- a/web-server/variables.tf
+++ b/web-server/variables.tf
@@ -30,14 +30,14 @@ variable "availability_domain" {
 }
 
 variable "TestServerShape" {
-  default = "VM.Standard2.1"
+  default = "VM.Standard.E3.Flex"
 }
 
 variable "InstanceImageOCID" {
   type = map(string)
 
   default = {
-    us-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaad7zlitmahc5w5m7hv47jiwooiy7vqethdsl4vexdc3sfcrzkvi3q"
+    eu-frankfurt-1 = "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaavz6p7tyrczcwd5uvq6x2wqkbwcrjjbuohbjomtzv32k5bq24rsha"
   }
 }
 


### PR DESCRIPTION
- Nastavil jsem vhodnější _shape_ pro VM a pro LB, aby nebyly problémy s kvótama.
- Testy by v kontinuální integraci vždycky spadly - kvůli neexistujícím (zakomentovaným), nebo chybným výstupním proměnným.

Testy máte napsané pěkně, s dobrým pokrytím :+1: 